### PR TITLE
fix backend compile errors for 2024.q1.12

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dummy Factory Portlet
 Bundle-SymbolicName: liferay.dummy.factory
-Bundle-Version: 7.4.2024.Q2.2
+Bundle-Version: 7.4.2024.Q1.12
 Web-ContextPath: /liferay-dummy-factory
 -dsannotations-options: inherit
 -sources: true

--- a/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
+++ b/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
@@ -83,7 +83,6 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         paramContext.getBaseDocumentDescription(), //description,
                         StringPool.BLANK, //changeLog,
                         new File(System.getProperty("java.io.tmpdir"), "dummy"), //file,
-                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());
@@ -105,7 +104,6 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         StringPool.BLANK, //changeLog,
                         tf.getContentStream(), //file,
                         tf.getSize(),
-                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());

--- a/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
+++ b/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
@@ -341,7 +341,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         size,
                         (Date) null,
                         (Date) null,
-                        (Date) null,
                         serviceContext);
 
             } else {
@@ -357,7 +356,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         dlVersionNumberIncrease,
                         inputStream,
                         size,
-                        (Date) null,
                         (Date) null,
                         (Date) null,
                         serviceContext);


### PR DESCRIPTION
### Issue:

Compilation for 2024.q1.12 resulted in a couple errors:

```
❯ blade gw assemble

> Task :modules:liferay-dummy-factory:compileJava
/Users/michihikoshiotani/Desktop/test_env/workspaces/2024.Q1.12/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java:85: error: incompatible types: File cannot be converted to InputStream
                        new File(System.getProperty("java.io.tmpdir"), "dummy"), //file,
                        ^
/Users/michihikoshiotani/Desktop/test_env/workspaces/2024.Q1.12/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java:95: error: no suitable method found for addFileEntry(<null>,long,long,long,String,String,String,String,String,String,InputStream,long,Date,Date,Date,ServiceContext)
                    _dLAppLocalService.addFileEntry(
                                      ^
    method DLAppLocalService.addFileEntry(long,long,long,String,String,String,String,String,File,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppLocalService.addFileEntry(String,long,long,long,String,String,byte[],Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppLocalService.addFileEntry(String,long,long,long,String,String,String,String,String,String,byte[],Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppLocalService.addFileEntry(String,long,long,long,String,String,String,String,String,String,File,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppLocalService.addFileEntry(String,long,long,long,String,String,String,String,String,String,InputStream,long,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
/Users/michihikoshiotani/Desktop/test_env/workspaces/2024.Q1.12/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java:331: error: no suitable method found for addFileEntry(<null>,long,long,String,String,String,String,String,String,InputStream,long,Date,Date,Date,ServiceContext)
                fileEntry = _dlAppService.addFileEntry(null,
                                         ^
    method DLAppService.addFileEntry(long,long,String,String,String,String,String,File,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppService.addFileEntry(String,long,long,String,String,String,String,String,String,byte[],Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppService.addFileEntry(String,long,long,String,String,String,String,String,String,File,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppService.addFileEntry(String,long,long,String,String,String,String,String,String,InputStream,long,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
/Users/michihikoshiotani/Desktop/test_env/workspaces/2024.Q1.12/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java:350: error: no suitable method found for updateFileEntry(long,String,String,String,String,String,String,DLVersionNumberIncrease,InputStream,long,Date,Date,Date,ServiceContext)
                fileEntry = _dlAppService.updateFileEntry(fileEntryId,
                                         ^
    method DLAppService.updateFileEntry(long,String,String,String,String,String,String,DLVersionNumberIncrease,byte[],Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppService.updateFileEntry(long,String,String,String,String,String,String,DLVersionNumberIncrease,File,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
    method DLAppService.updateFileEntry(long,String,String,String,String,String,String,DLVersionNumberIncrease,InputStream,long,Date,Date,ServiceContext) is not applicable
      (actual and formal argument lists differ in length)
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
4 errors

> Task :modules:liferay-dummy-factory:compileJava FAILED
```

### Fix:

Upon looking at the DXP source code for the `DLAppLocalService` interface, the `displayDate` argument was removed, so I removed the use of them.

### Notes:

The `displayDate` argument was recently added in the commit below, about a week ago, so it seems strange to have to remove it...:

604611a4e4e8781189d62ed53d542684944bea34

Just wanted to check about this.