### PR TITLE
2024.q3.5 fix

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dummy Factory Portlet
 Bundle-SymbolicName: liferay.dummy.factory
-Bundle-Version: 7.4.2024.Q2.2
+Bundle-Version: 7.4.2024.Q1.12
 Web-ContextPath: /liferay-dummy-factory
 -dsannotations-options: inherit
 -sources: true

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dummy Factory Portlet
 Bundle-SymbolicName: liferay.dummy.factory
-Bundle-Version: 7.4.2024.Q1.12
+Bundle-Version: 7.4.2024.Q3.5
 Web-ContextPath: /liferay-dummy-factory
 -dsannotations-options: inherit
 -sources: true

--- a/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
+++ b/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
@@ -83,7 +83,6 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         paramContext.getBaseDocumentDescription(), //description,
                         StringPool.BLANK, //changeLog,
                         new File(System.getProperty("java.io.tmpdir"), "dummy"), //file,
-                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());
@@ -105,7 +104,6 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         StringPool.BLANK, //changeLog,
                         tf.getContentStream(), //file,
                         tf.getSize(),
-                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());

--- a/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
+++ b/src/main/java/com/liferay/support/tools/document/library/DLDefaultDummyGenerator.java
@@ -83,6 +83,7 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         paramContext.getBaseDocumentDescription(), //description,
                         StringPool.BLANK, //changeLog,
                         new File(System.getProperty("java.io.tmpdir"), "dummy"), //file,
+                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());
@@ -104,6 +105,7 @@ public class DLDefaultDummyGenerator extends DummyGenerator<DLContext> {
                         StringPool.BLANK, //changeLog,
                         tf.getContentStream(), //file,
                         tf.getSize(),
+                        (Date)null, // displayDate
                         (Date)null, // expirationDate
                         (Date)null, // reviewDate
                         paramContext.getServiceContext());

--- a/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
+++ b/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
@@ -341,6 +341,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         size,
                         (Date) null,
                         (Date) null,
+                        (Date) null,
                         serviceContext);
 
             } else {
@@ -356,6 +357,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         dlVersionNumberIncrease,
                         inputStream,
                         size,
+                        (Date) null,
                         (Date) null,
                         (Date) null,
                         serviceContext);

--- a/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
+++ b/src/main/java/com/liferay/support/tools/document/library/EditFileEntryMVCActionCommand.java
@@ -341,7 +341,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         size,
                         (Date) null,
                         (Date) null,
-                        (Date) null,
                         serviceContext);
 
             } else {
@@ -357,7 +356,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
                         dlVersionNumberIncrease,
                         inputStream,
                         size,
-                        (Date) null,
                         (Date) null,
                         (Date) null,
                         serviceContext);

--- a/src/main/java/com/liferay/support/tools/page/PageDefaultDummyGenerator.java
+++ b/src/main/java/com/liferay/support/tools/page/PageDefaultDummyGenerator.java
@@ -51,13 +51,14 @@ public class PageDefaultDummyGenerator extends DummyGenerator<PageContext> {
 
 			try {
 				_layoutLocalService.addLayout(
+					StringPool.BLANK, //externalReferenceCode
 					paramContext.getServiceContext().getUserId(), 
 					paramContext.getGroupId(), //groupId
 					paramContext.isPrivateLayout(), //privateLayout
 					paramContext.getParentLayoutId(), //parentLayoutId
-					name.toString(), //nameMap
-					StringPool.BLANK, //titleMap
-					StringPool.BLANK, //descriptionMap
+					name.toString(), //name
+					StringPool.BLANK, //title
+					StringPool.BLANK, //description
 					paramContext.getLayoutType(), //type
 					paramContext.isHidden(), //hidden
 					StringPool.BLANK, //friendlyURL

--- a/src/main/java/com/liferay/support/tools/user/UserLayoutUtil.java
+++ b/src/main/java/com/liferay/support/tools/user/UserLayoutUtil.java
@@ -223,7 +223,7 @@ public class UserLayoutUtil {
         ServiceContext serviceContext = new ServiceContext();
 
         Layout layout = LayoutLocalServiceUtil.addLayout(
-            userId, groupId, true, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+            StringPool.BLANK, userId, groupId, true, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
             PropsValues.DEFAULT_USER_PRIVATE_LAYOUT_NAME, StringPool.BLANK,
             StringPool.BLANK, LayoutConstants.TYPE_PORTLET, false, friendlyURL,
             serviceContext);
@@ -385,7 +385,7 @@ public class UserLayoutUtil {
         ServiceContext serviceContext = new ServiceContext();
 
         Layout layout = LayoutLocalServiceUtil.addLayout(
-            userId, groupId, false, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+            StringPool.BLANK, userId, groupId, false, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
             PropsValues.DEFAULT_USER_PUBLIC_LAYOUT_NAME, StringPool.BLANK,
             StringPool.BLANK, LayoutConstants.TYPE_PORTLET, false, friendlyURL,
             serviceContext);


### PR DESCRIPTION
### Background

Since support for JDK 11 was removed starting from version 2024.q3,
I tested compilation of dummy-factory using JDK 17 and 21, building for 2024.q3.5.
While there were no issues stemming from the use of JDK 17 & 21,
there were issues from the Java API interface changing again in 2024.q3, which I've fixed in this PR.

### Specific fixes

- Reverted change originally made for 2024.q1.12
- Had to add an extra argument in places calling `_layoutLocalService.addLayout() `
- Added jar build for 2024.q3.5