### PR TITLE
fix: migrate StringBundler import to com.liferay.petra.string for DXP 2026

### DIFF
--- a/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/utils/DDMLocalUtil.java
+++ b/modules/liferay-dummy-factory/src/main/java/com/liferay/support/tools/utils/DDMLocalUtil.java
@@ -2,10 +2,10 @@ package com.liferay.support.tools.utils;
 
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;


### PR DESCRIPTION
## Problem

`:modules:liferay-dummy-factory:compileJava` was failing on `master`, causing the `unit-test` job (`./gradlew :modules:liferay-dummy-factory:test`) to fail on every new PR.

```
DDMLocalUtil.java:8:  error: cannot find symbol  → import com.liferay.portal.kernel.util.StringBundler;
DDMLocalUtil.java:77: error: cannot find symbol  → new StringBundler(...)
> Task :modules:liferay-dummy-factory:compileJava FAILED
```

## Cause

In DXP 2026.q1.3-LTS, `StringBundler` was moved from `com.liferay.portal.kernel.util` to `com.liferay.petra.string.StringBundler`. Because `DDMLocalUtil.java` imported the old package, it could not be resolved against the target platform, causing the entire compilation to fail.

## Fix

Changed the single import line in `DDMLocalUtil.java` to the new package (the same file already resolves `com.liferay.petra.string.StringPool`, so this package is present on the classpath).

## Verification

- `./gradlew :modules:liferay-dummy-factory:compileJava` → **BUILD SUCCESSFUL**
- `./gradlew :modules:liferay-dummy-factory:test --no-daemon` (identical to CI: compile + host-JVM unit tests + JaCoCo) → **BUILD SUCCESSFUL**
