### PR TITLE
build: upgrade to Liferay DXP 2026.Q1.9-LTS

### DIFF
--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -109,6 +109,6 @@ Silent skips and silently disabled type checking are easy to introduce. Mock typ
 
 ## Known DXP 2026 API constraints
 
-DXP 2026.Q1.3-LTS has several non-obvious API constraints (`GroupLocalService.addGroup` new 18-arg signature,
+DXP 2026.Q1.9-LTS has several non-obvious API constraints (`GroupLocalService.addGroup` new 18-arg signature,
 `CompanyService` blacklist, `MBThreadLocalService.getThreads` exact-match categoryId, `group/delete-group`
 returning 404, `bnd.bnd` javax.servlet exclusion, etc.). Full catalog in `docs/details/api-liferay-dxp2026.md`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -13,7 +13,7 @@ L2 layer for test design, execution strategy, and verification. Read this when w
 
 ## Container setup
 
-- Docker image: `liferay/dxp:2026.q1.3-lts`.
+- Docker image: `liferay/dxp:2026.q1.9-lts`.
 - Singleton pattern: `LiferayContainer.getInstance()` provides configuration constants shared across all specs. Container lifecycle is managed by workspace Gradle tasks, not by `LiferayContainer`.
 - Startup timeout: **8 minutes** (`awaitLiferayReady` Gradle task polls `http://localhost:8080/c/portal/login`).
 - Fixed ports: **8080** (HTTP), **11311** (GoGo Shell), **8000** (JPDA). Access via system properties `liferay.http.port` / `liferay.gogo.port` set by `integrationTest` task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # liferay-dummy-factory
 
-Liferay DXP 2026.Q1.3-LTS Workspace: MVCPortlet + React portlet + Spock integration tests against `liferay/dxp:2026.q1.3-lts`.
+Liferay DXP 2026.Q1.9-LTS Workspace: MVCPortlet + React portlet + Spock integration tests against `liferay/dxp:2026.q1.9-lts`.
 
 ## Routing — read the matching L2 file for the task you're starting
 
@@ -18,7 +18,7 @@ Liferay DXP 2026.Q1.3-LTS Workspace: MVCPortlet + React portlet + Spock integrat
 2. **Single source of truth** — every fact, rule, or contract lives in exactly one file. Other files link to it.
 3. **Creator + batch response contract** — `*Creator` classes wrap per-entity work in `TransactionInvokerUtil.invoke` + `throws Throwable` and return `{success, count, requested, skipped, error?, items}` with strict `success := created == requested`; `error` MUST be set whenever `success == false`. Detail in `.claude/rules/writing-code.md`.
 4. **JSONWS-first verification** — test post-conditions through `/api/jsonws/...`, not Playwright UI navigation. Detail in `.claude/rules/testing.md`.
-5. **`jakarta.portlet` 4.0** — DXP 2026.Q1.3-LTS uses `jakarta.portlet.*` imports and `jakarta.portlet.version=4.0` component properties. JSP taglib URI stays `http://xmlns.jcp.org/portlet_3_0` (JCP namespace). See `docs/ADR/adr-0008-dxp-2026-migration.md`.
+5. **`jakarta.portlet` 4.0** — DXP 2026.Q1.9-LTS uses `jakarta.portlet.*` imports and `jakarta.portlet.version=4.0` component properties. JSP taglib URI stays `http://xmlns.jcp.org/portlet_3_0` (JCP namespace). See `docs/ADR/adr-0008-dxp-2026-migration.md`.
 6. **`data-testid` is mechanically named** — `${entityKey}-${kebab(field)}-${typeSuffix}`. Do not invent ids; follow the contract in `.claude/rules/writing-code.md`.
 7. **One package manager per repo** — `yarn.lock` only. Never coexist with `package-lock.json`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ready-made samples live under `integration-test/src/test/resources/workflow-samp
 
 ## Required environment
 * Java 21 or above
-* Liferay DXP 2026.Q1.3-LTS (this branch)
+* Liferay DXP 2026.Q1.9-LTS (this branch)
 * Liferay 7.4 (please see the 7.4.x branch)
 * Liferay 7.3 GA1 (please see the 7.3.x branch)
 * Liferay 7.2 (please see the 7.2.x branch)
@@ -49,7 +49,7 @@ Ready-made samples live under `integration-test/src/test/resources/workflow-samp
 
 | Layer | Technology |
 |-------|------------|
-| Portal | Liferay DXP 2026.Q1.3-LTS |
+| Portal | Liferay DXP 2026.Q1.9-LTS |
 | Backend | MVCPortlet + MVCResourceCommand (layered) |
 | Frontend | React + Clay CSS |
 | Build | Gradle 8.5 + Liferay Workspace Plugin 10.1.9 |

--- a/docs/details/api-liferay-dxp2026.md
+++ b/docs/details/api-liferay-dxp2026.md
@@ -1,6 +1,6 @@
-# Liferay DXP 2026.Q1.3-LTS — API notes
+# Liferay DXP 2026.Q1.9-LTS — API notes
 
-L3 detail. Non-obvious API facts for DXP 2026.Q1.3-LTS. This file is the single source of truth for DXP 2026 API constraints. It replaces `api-liferay-ce74.md` (deleted). Read on demand from `.claude/rules/writing-code.md` or `.claude/rules/debugging.md`.
+L3 detail. Non-obvious API facts for DXP 2026.Q1.9-LTS. This file is the single source of truth for DXP 2026 API constraints. It replaces `api-liferay-ce74.md` (deleted). Read on demand from `.claude/rules/writing-code.md` or `.claude/rules/debugging.md`.
 
 ## 1. `release.dxp.api` BOM replaces individual API dependencies
 
@@ -142,7 +142,7 @@ Portal-core services use simple paths: `/api/jsonws/user/get-user-by-email-addre
 
 The module name matches the `Bundle-SymbolicName` prefix (e.g. `com.liferay.blogs.service` → `blogs`). Omitting the prefix returns HTTP 404.
 
-Note: DXP 2026.Q1.3-LTS exposes JSONWS at `/api/jsonws/` (unchanged from earlier releases). `BaseLiferaySpec.jsonwsGet/Post` centralizes this; individual specs pass only the path suffix.
+Note: DXP 2026.Q1.9-LTS exposes JSONWS at `/api/jsonws/` (unchanged from earlier releases). `BaseLiferaySpec.jsonwsGet/Post` centralizes this; individual specs pass only the path suffix.
 
 ## 12. `PanelCategoryKeys.CONTROL_PANEL_APPS` — `MARKETPLACE` constant does not exist in CE 7.4
 
@@ -164,7 +164,7 @@ Without this exclusion the bundle will show as UNSATISFIED in GoGo Shell even th
 
 ## 14. JSONWS base path is `/api/jsonws/`
 
-DXP 2026.Q1.3-LTS keeps the JSONWS base path at `/api/jsonws/`. Earlier migration notes speculated the path had moved to `/portal/api/jsonws/`, but `/portal/api/jsonws/*` is not registered in this release and returns 404.
+DXP 2026.Q1.9-LTS keeps the JSONWS base path at `/api/jsonws/`. Earlier migration notes speculated the path had moved to `/portal/api/jsonws/`, but `/portal/api/jsonws/*` is not registered in this release and returns 404.
 
 `BaseLiferaySpec.jsonwsGet/Post` centralizes the base path. Individual specs and cleanup code must never hard-code the full path — pass only the suffix (e.g. `'user/get-current-user'`). When sweeping for old-path references, grep both dotted access and string literals:
 

--- a/docs/details/dxp-2026-gotchas.md
+++ b/docs/details/dxp-2026-gotchas.md
@@ -1,4 +1,4 @@
-# DXP 2026.Q1.3-LTS — Runtime and Environment Gotchas
+# DXP 2026.Q1.9-LTS — Runtime and Environment Gotchas
 
 L3 detail. Concrete pitfalls discovered during DXP 2026 migration. Read on demand from `.claude/rules/debugging.md`.
 
@@ -6,7 +6,7 @@ L3 detail. Concrete pitfalls discovered during DXP 2026 migration. Read on deman
 
 **Symptom**: Every JSONWS call returns HTTP 403 or "Access denied" immediately after the container starts. No `configs/` change seems to help.
 
-**Root cause**: `liferay/dxp:2026.q1.3-lts` bakes `/home/liferay/portal-liferay-online-config.properties` into the image. This file contains:
+**Root cause**: `liferay/dxp:2026.q1.9-lts` bakes `/home/liferay/portal-liferay-online-config.properties` into the image. This file contains:
 
 ```
 json.servlet.hosts.allowed=N/A

--- a/docs/details/testing-gradle.md
+++ b/docs/details/testing-gradle.md
@@ -2,7 +2,7 @@
 
 L3 detail. Source of truth for Gradle task wiring, deploy verification, the incremental build trap, and JaCoCo coverage. Read on demand from `.claude/rules/testing.md` or `.claude/rules/debugging.md`.
 
-This file reflects the DXP 2026.Q1.3-LTS workspace-native Docker flow. The Testcontainers-based approach used for CE 7.4 GA132 has been removed. See `docs/ADR/adr-0008-dxp-2026-migration.md` for the migration decisions.
+This file reflects the DXP 2026.Q1.9-LTS workspace-native Docker flow. The Testcontainers-based approach used for CE 7.4 GA132 has been removed. See `docs/ADR/adr-0008-dxp-2026-migration.md` for the migration decisions.
 
 ## License requirement (DXP 2026)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-liferay.workspace.product=dxp-2026.q1.3-lts
+liferay.workspace.product=dxp-2026.q1.9-lts
 liferay.workspace.node.package.manager=yarn
 liferay.workspace.default.repository.enabled=true
-liferay.workspace.target.platform.version=2026.q1.3
+liferay.workspace.target.platform.version=2026.q1.9
 liferay.workspace.bundle.metadata.enabled=true
 
 # Gradle daemon JDK 21 — set the actual path in ~/.gradle/gradle.properties, not here.

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -108,7 +108,7 @@ gradle.projectsEvaluated {
 		// of which address the JVM picks for "localhost".
 		//
 		// exposePorts is ALSO required: unlike 8080/11311/8000 which are EXPOSE'd
-		// in liferay/dxp:2026.q1.3-lts, port 6300 is unknown to the base image.
+		// in liferay/dxp:2026.q1.9-lts, port 6300 is unknown to the base image.
 		// Docker silently drops portBindings for ports that are neither EXPOSE'd
 		// by the image nor added to the container's ExposedPorts, producing the
 		// symptom that 6300 appears in HostConfig.PortBindings but never reaches


### PR DESCRIPTION
## Summary

Bumps the workspace target platform from Liferay DXP `2026.Q1.3-LTS` to `2026.Q1.9-LTS`, staying on the Q1 LTS line (Q2 is a shorter-support standard quarterly). The only functional change is the two version pins in `gradle.properties`; the rest is current-state documentation catching up to the new version string. No production Java, JSP, React, or test logic is touched.

## Background / Motivation

- The workspace was pinned to `2026.q1.3-lts`, the earliest patch of the DXP 2026 Q1 LTS line. Q1.9-LTS is the current LTS patch, so the pin was several security/bugfix patches behind with no functional reason to stay.
- The version string was duplicated verbatim across `README.md`, `CLAUDE.md`, the `.claude/rules/*` L2 docs, and `docs/details/*` — leaving them at Q1.3 after bumping the pin would violate the repo's single-source-of-truth contract and mislead the next reader about which image the suite actually runs against.
- The two ADRs that mention Q1.3 (`adr-0001`, `adr-0008`) are historical decision records, not current-state docs, so they must **not** be rewritten — the version they cite is the version that was current when the decision was made.

## Changes

### Version pin (`gradle.properties`)

- `liferay.workspace.product`: `dxp-2026.q1.3-lts` → `dxp-2026.q1.9-lts`
- `liferay.workspace.target.platform.version`: `2026.q1.3` → `2026.q1.9`

These two lines drive the target-platform BOM (`release.dxp.api:2026.q1.9`) and the Docker image tag (`liferay/dxp:2026.q1.9-lts`) used by the integration suite.

### Documentation alignment

- `Q1.3-LTS` → `Q1.9-LTS` and `q1.3-lts` → `q1.9-lts` across current-state docs: `README.md`, `CLAUDE.md`, `.claude/rules/testing.md`, `.claude/rules/debugging.md`, `docs/details/api-liferay-dxp2026.md`, `docs/details/dxp-2026-gotchas.md`, `docs/details/testing-gradle.md`, and one comment in `integration-test/build.gradle`.
- String-literal-only edits (applied via `sed` to avoid formatter reflow noise) — no prose, table, or structural changes.

### Intentionally untouched

- `docs/ADR/adr-0001-integration-test-architecture.md` and `docs/ADR/adr-0008-dxp-2026-migration.md` keep their original `2026.Q1.3-LTS` references as historical records.

## Verification

Full clean cold-boot integration suite run against `liferay/dxp:2026.q1.9-lts`:

- The bundle JAR builds against the `release.dxp.api:2026.q1.9` BOM.
- The bundle `liferay.dummy.factory` reaches **ACTIVE** on DXP 2026.Q1.9-LTS — GoGo `lb dummy.factory` shows `1527|Active|...Liferay Dummy Factory Portlet (2.0.0)`.
- Integration suite: **99 tests, 97 passed, 1 skipped, 1 failed**.
- The single failure is a **pre-existing flaky UI test** (`WorkflowJsonWorkspaceSpec`, `setForce(true)` racing the on-mount schema fetch), **not a Q1.9 regression**: the schema endpoint is bundle-provided (`/o/ldf-workflow/schema`) and DXP-version-independent, and the test fails on both cold and warm boots. Tracked separately in #76.

## Test plan

- [ ] `./gradlew :modules:liferay-dummy-factory:clean :integration-test:clean && ./gradlew :integration-test:integrationTest` — `BUILD SUCCESSFUL` with an elapsed time in minutes (not single-digit seconds, which would be a cached replay). 97 passed / 1 skipped / 1 pre-existing flaky.
- [ ] `docker exec <project>-liferay bash -c "(echo 'lb dummy.factory'; sleep 2) | telnet localhost 11311"` — the bundle line reads `Active`.
- [ ] `grep -rn 'q1\.3-lts\|Q1\.3-LTS' README.md CLAUDE.md .claude/rules docs/details integration-test/build.gradle` — returns nothing (all current-state docs bumped).
- [ ] `grep -rn 'Q1\.3-LTS' docs/ADR` — still returns the two ADR references (historical records intentionally left in place).
