### PR TITLE
fix(test): await enabled Execute button in WorkflowJsonWorkspaceSpec

### DIFF
--- a/integration-test/src/test/groovy/com/liferay/support/tools/it/spec/WorkflowJsonWorkspaceSpec.groovy
+++ b/integration-test/src/test/groovy/com/liferay/support/tools/it/spec/WorkflowJsonWorkspaceSpec.groovy
@@ -213,10 +213,12 @@ class WorkflowJsonWorkspaceSpec extends BaseLiferaySpec {
 		editor.waitFor(new Locator.WaitForOptions().setTimeout(30_000))
 		editor.fill('')
 
-		and: 'Execute is clicked'
-		page.locator(
-			"[data-testid=\"${WORKFLOW_JSON_EXECUTE_TEST_ID}\"]"
-		).click(new Locator.ClickOptions().setForce(true))
+		and: 'Execute becomes enabled after the schema loads, then is clicked'
+		Locator executeButton = page.locator(
+			"[data-testid=\"${WORKFLOW_JSON_EXECUTE_TEST_ID}\"]:not([disabled])"
+		)
+		executeButton.waitFor(new Locator.WaitForOptions().setTimeout(30_000))
+		executeButton.click()
 
 		then: 'the result pane appears with an Ajv source badge'
 		Locator resultPanel = page.locator(


### PR DESCRIPTION
Closes #76

## Problem

`WorkflowJsonWorkspaceSpec` > "shows Ajv empty-variant result in the result pane when Execute is clicked with empty editor" failed non-deterministically with a Playwright `TimeoutError`. It force-clicked the async-gated Execute button with `setForce(true)` before the button was enabled — exactly the anti-pattern the repo's own rule forbids (`.claude/rules/testing.md`, "Playwright async-gated buttons"). This is the pre-existing flaky test called out in #78 ("Tracked separately in #76"). Test-only defect; no production code involved.

## Cause

- In `WorkflowJsonEditor.tsx`, the Execute button is `disabled={!canExecute || isBusy}`, where `canExecute = Boolean(executeResourceURL) && schemaReady`.
- `schemaReady` only flips to `true` after the on-mount `fetch('/o/ldf-workflow/schema')` (`initSchema()` in `workflowJsonSchema.ts`) resolves. Until then Execute is **disabled**.
- The test opened the tab and immediately force-clicked Execute without waiting for that schema fetch. A forced click on a disabled button does not fire `onClick`, so the danger result panel never rendered and the following `resultPanel.waitFor(5_000)` timed out. It reproduces on both cold and warm boots — a structural race (no wait), not a mere timing flake.

## Fix

In the `and: 'Execute is clicked'` block, AND `:not([disabled])` onto the selector, wait for it with an independent 30s timeout, then click normally (no `setForce`):

```groovy
Locator executeButton = page.locator(
    "[data-testid=\"${WORKFLOW_JSON_EXECUTE_TEST_ID}\"]:not([disabled])"
)
executeButton.waitFor(new Locator.WaitForOptions().setTimeout(30_000))
executeButton.click()
```

A plain `click()` also runs Playwright's actionability checks (visible/enabled/stable), so the enabled-wait is doubly guaranteed.

### Scope (kept atomic)

- Changes **only** the single Execute call (1 file, +6/−4). The other three `setForce(true)` calls in the same file (`_expandResultDetailsIfAvailable` / `_clickFirstVisibleIfPresent` / `_clickFirstVisible`) act on result-detail toggles / generic helpers, not async-gated Plan/Execute buttons — left unchanged.
- No diff in production code (`src/main/**`). `Locator` was already imported; no new import.
- The `then:` block (5s `resultPanel` wait, `sourceBadge == 'Ajv'`, "Workflow JSON is required" assertion) is unchanged — once the button is actually clicked, Ajv validation runs synchronously client-side.

## Verification

- `./gradlew :integration-test:compileTestGroovy` → **BUILD SUCCESSFUL** (specs compile; `compileTestGroovy`, not `compileGroovy`, per `.claude/rules/debugging.md`).
- Container-based verification requires Docker + a Liferay license and was not run here (`LIFERAY_DXP_LICENSE_FILE` / `LIFERAY_DXP_LICENSE_BASE64` unset). To confirm deterministic passing locally:

```bash
./gradlew :modules:liferay-dummy-factory:jar
LIFERAY_DXP_LICENSE_FILE=/path/to/activation-key.xml \
  ./gradlew :integration-test:integrationTest --tests "*WorkflowJsonWorkspaceSpec*"
```

## Test plan

- [ ] `./gradlew :integration-test:compileTestGroovy` → `BUILD SUCCESSFUL`.
- [ ] `./gradlew :integration-test:integrationTest --tests "*WorkflowJsonWorkspaceSpec*"` → every feature method passes (`... 0 failed`) on both cold and warm boots.
- [ ] The other tests in the spec ("runs plan and execute...", "Legacy entity form...", "shows progress bar while Execute is in-flight") still pass.
- [ ] `grep -n "setForce" integration-test/src/test/groovy/com/liferay/support/tools/it/spec/WorkflowJsonWorkspaceSpec.groovy` → exactly 3 matches (the out-of-scope helper calls), none on the Execute button.
