### PR TITLE
chore: pin yarn 1.22.22 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 java = "temurin-21.0.10+7.0.LTS"
 node = "20.12.2"
+yarn = "1.22.22"


### PR DESCRIPTION
## Summary

Pins Yarn in the repo's `mise.toml` so the local toolchain fully specifies the project's package manager alongside the already-pinned Java and Node. Until now `mise.toml` covered only `java` and `node`, leaving Yarn to whatever version each contributor happened to have on `PATH`.

## Background / Motivation

- The workspace is a Yarn-classic project (`yarn.lock` v1, `liferay.workspace.node.package.manager=yarn` in `gradle.properties`), yet `mise.toml` pinned only `java = "temurin-21.0.10+7.0.LTS"` and `node = "20.12.2"`. Yarn was unmanaged, so a contributor running Yarn 3/4 could regenerate `yarn.lock` in an incompatible format.
- Java 21 and Node 20.12.2 already match the CI pins in `.github/workflows/unit-test.yml` / `integration-test.yml`; Yarn was the one toolchain axis without parity.
- `1.22.22` is the version already resolved locally (`yarn --version`) and the format that produced the committed lockfile (`# yarn lockfile v1`).

## Changes

### `mise.toml`

- Add `yarn = "1.22.22"` under `[tools]`, next to the existing `java` and `node` entries. One-line addition; no other keys touched.

## Verification

- With mise active at the repo root, `mise ls --current` lists `yarn 1.22.22` sourced from the repo's `mise.toml` (not `~/.config/mise/config.toml`).
- `mise install` materializes the pinned binary; afterward `yarn --version` prints `1.22.22`.
- CI is unaffected — it provisions Yarn via `corepack enable`, independent of `mise.toml`.

## Test plan

- [ ] `mise ls --current` — the `yarn` row reads `1.22.22` and points at the repo `mise.toml`.
- [ ] `mise install && yarn --version` → `1.22.22`.
- [ ] `head -3 yarn.lock` still reads `# yarn lockfile v1` (the classic format the pin matches).
- [ ] CI (`unit-test.yml` / `integration-test.yml`) stays green — no dependence on `mise.toml`.
